### PR TITLE
Replace ob_start with http2_link_preload_header in add_action

### DIFF
--- a/http2-server-push.php
+++ b/http2-server-push.php
@@ -10,7 +10,7 @@ Author URI:  http://davidmichaelross.com
 */
 
 // Start an output buffer so this plugin can call header() later without errors
-add_action( 'template_redirect', 'ob_start' );
+add_action( 'template_redirect', 'http2_link_preload_header' );
 
 /**
  * @param string $src URL


### PR DESCRIPTION
Replace ob_start with http2_link_preload_header in add_action to fix https://github.com/daveross/http2-server-push/issues/2
