### PR TITLE
Use site_url to compare with content URLs

### DIFF
--- a/http2-server-push.php
+++ b/http2-server-push.php
@@ -50,7 +50,7 @@ function http2_link_preload_header($src) {
 
 	global $http2_header_size_accumulator;
 
-    if (strpos($src, home_url()) !== false) {
+    if (strpos($src, site_url()) !== false) {
 
         $preload_src = apply_filters('http2_link_preload_src', $src);
 


### PR DESCRIPTION
Hello, We got a report that this plugin is not working with WPML on translated pages. [Ticket link](https://wpml.org/forums/topic/http-2-server-push-is-working-only-on-default-language-english/)

Since Server Push matching domain of resource URL with home URL and WPML translate the home URL thus it doesn't match. e.g. http://example.com/fr/ replacing it with site URL fix the issue. 
Also, content URL constructed using site URL itself so it will be good even when not using WPML.