### PR TITLE
Use root URL to check against resource URL

### DIFF
--- a/http2-server-push.php
+++ b/http2-server-push.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 /*
 Plugin Name: HTTP/2 Server Push
@@ -50,7 +50,9 @@ function http2_link_preload_header($src) {
 
 	global $http2_header_size_accumulator;
 
-    if (strpos($src, site_url()) !== false) {
+	$host = parse_url(home_url(), PHP_URL_HOST);
+
+    if (strpos($host, $host) !== false) {
 
         $preload_src = apply_filters('http2_link_preload_src', $src);
 
@@ -67,10 +69,10 @@ function http2_link_preload_header($src) {
 				$http2_header_size_accumulator += strlen($header);
 				header( $header, false );
 			}
-			
-			
+
+
 			$GLOBALS['http2_' . http2_link_resource_hint_as( current_filter() ) . '_srcs'][] = http2_link_url_to_relative_path( $preload_src );
-		
+
 		}
 
     }
@@ -93,7 +95,7 @@ function http2_resource_hints() {
 		$resources = http2_get_resources($GLOBALS, $resource_type);
 		array_walk( $resources, function( $src ) use ( $resource_type ) {
 			printf( '<link rel="preload" href="%s" as="%s">', esc_url($src), esc_html( $resource_type ) );
-		});	
+		});
 	});
 
 }
@@ -113,7 +115,7 @@ function http2_get_resources($globals = null, $resource_type) {
 
 	$globals = (null === $globals) ? $GLOBALS : $globals;
 	$resource_type_key = "http2_{$resource_type}_srcs";
-	
+
 	if(!(is_array($globals) && isset($globals[$resource_type_key]))) {
 		return array();
 	}


### PR DESCRIPTION
Hi, 

Using `site_url` to get the "root" URL is always wrong. `site_url` is the path to WordPress. Indeed, most of the time (regular WP structure) `home_url` == `site_url`. But it can sometimes be different. In my case (using Bedrock or any WordPress-in-a-subdirectory structure type), `site_url` is `https://domain.com/wp`. This kind of setup is pretty popular among developers. 

As pointed out in #19, multi language plugins such Polylang or WPML change the value of `home_url`. That's why this PR parses home URL to extract the root domain only.

Maybe the comparison should be more accurate. An edge case like `https://externaldomain.com/domain.com.css` would match the check. But yes, it is far-fetched and very unlikely to happen 😄 